### PR TITLE
Implement friendlier syntax extension

### DIFF
--- a/src/main/java/duke/Augury.java
+++ b/src/main/java/duke/Augury.java
@@ -26,7 +26,7 @@ import duke.ui.Ui;
  * @author Jefferson (@qreoct)
  */
 public class Augury {
-    private final String VER     = "v1.0.0"; // Level-10 GUI
+    private final String VER     = "v1.1.0"; // C-Friendlier-Syntax
     private final String WELCOME =
             "\t+-------------------------------+\n" +
             "\t| *                 *         * |\n" +

--- a/src/main/java/duke/commands/CommandTypes.java
+++ b/src/main/java/duke/commands/CommandTypes.java
@@ -1,13 +1,26 @@
 package duke.commands;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Enumerates the command types supported by Augury.
  */
 public enum CommandTypes {
-    QUIT,
-    LIST,
-    MARKDONE,
-    DELETE,
-    MAKE,
-    FIND
+    QUIT("quit", "exit", "bye", "q"),
+    LIST("list", "ls", "l"),
+    MARKDONE("done"),
+    DELETE("delete", "del", "rm"),
+    MAKE("todo", "deadline", "event"),
+    FIND("find", "f");
+
+    private final List<String> aliases;
+
+    CommandTypes(String... aliases) {
+        this.aliases = Arrays.asList(aliases);
+    }
+
+    public List<String> getAliases() {
+        return aliases;
+    }
 }

--- a/src/main/java/duke/commands/DeleteCommand.java
+++ b/src/main/java/duke/commands/DeleteCommand.java
@@ -39,8 +39,9 @@ public class DeleteCommand extends Command {
         String args = this.args[0];
         ArrayList<Integer> listOfTasks = StringCleaner.toArrayListInteger(args);
 
+        int taskListSize = tasks.size();
         for (Integer i : listOfTasks) {
-            if (i > tasks.size()) {
+            if (i > taskListSize || i <= 0) {
                 throw new InvalidActionException("Task " + i + " does not exist.");
             }
         }

--- a/src/main/java/duke/commands/FindCommand.java
+++ b/src/main/java/duke/commands/FindCommand.java
@@ -33,10 +33,6 @@ public class FindCommand extends Command {
     @Override
     public String execute(TaskList tasks, Storage storage) throws InvalidActionException {
         String query = this.args[0];
-        if (query.equals("find")) {
-            // bug: for (valid) command `find find`, this exception is thrown.
-            throw new InvalidActionException("Please enter the search string you want to find.");
-        }
         return tasks.findAndAnnounce(query);
     }
 }

--- a/src/main/java/duke/commands/MakeCommand.java
+++ b/src/main/java/duke/commands/MakeCommand.java
@@ -39,23 +39,23 @@ public class MakeCommand extends Command {
         String args = this.args[0];
 
         // type will be in the first word
-        String type = args.split(" ")[0];
+        String taskType = args.split(" ")[0];
 
-        String description;
-        if (args.length() == type.length()) {
-            description = ""; // no description provided
+        String taskDescription;
+        if (args.length() == taskType.length()) {
+            taskDescription = ""; // no description provided
         } else {
-            description = args.replace(type + " ", "");
+            taskDescription = args.replace(taskType + " ", "");
         }
 
         try {
             TaskFactory tf = new TaskFactory();
-            Task newTask = tf.createTask(type, description);
+            Task newTask = tf.createTask(taskType, taskDescription);
 
             if (newTask == null) {
                 throw new UnknownCommandException("Invalid command entered when creating task.");
             }
-            String result = tasks.addTaskAndAnnounce(type, newTask);
+            String result = tasks.addTaskAndAnnounce(taskType, newTask);
             storage.saveTaskListToStorage(tasks);
             return result;
         } catch (AuguryException e) {

--- a/src/main/java/duke/commands/MarkDoneCommand.java
+++ b/src/main/java/duke/commands/MarkDoneCommand.java
@@ -39,8 +39,9 @@ public class MarkDoneCommand extends Command {
         String args = this.args[0];
         ArrayList<Integer> listOfTasks = StringCleaner.toArrayListInteger(args);
 
+        int taskListSize = tasks.size();
         for (Integer i : listOfTasks) {
-            if (i > tasks.size()) {
+            if (i > taskListSize || i <= 0) {
                 throw new InvalidActionException("Task " + i + " does not exist.");
             }
         }

--- a/src/main/java/duke/io/Parser.java
+++ b/src/main/java/duke/io/Parser.java
@@ -3,7 +3,6 @@ package duke.io;
 import duke.commands.Command;
 import duke.commands.CommandTypes;
 import duke.exceptions.AuguryException;
-import duke.exceptions.InvalidActionException;
 import duke.exceptions.UnknownCommandException;
 
 /**
@@ -21,31 +20,36 @@ public class Parser {
      */
     public Command parse(String input) throws AuguryException {
 
-        if (input.equals("bye") || input.equals("exit") || input.equals("quit")) {
-            return Command.of(CommandTypes.QUIT);
-        } else if (input.equals("list") || input.equals("ls")) {
-            return Command.of(CommandTypes.LIST);
-        } else if (input.startsWith("done")) {
-            String indexes = input.substring(4).trim();
-            if (indexes.length() == 0) {
-                throw new InvalidActionException("Please enter the task number which you want to mark as done.");
+        // search through valid CommandTypes and their aliases
+        // gleaned from https://stackoverflow.com/questions/4197988/java-enum-valueof-with-multiple-values/4198066#4198066
+        for (CommandTypes commandType : CommandTypes.values()) {
+            for (String alias : commandType.getAliases()) {
+                if (input.startsWith(alias)) {
+                    String args = cleanCommandArguments(input, alias, commandType);
+                    if (args != null && args.equals("")) {
+                        throw new UnknownCommandException("Please enter an argument!");
+                    }
+                    return Command.of(commandType, args);
+                }
             }
-            return Command.of(CommandTypes.MARKDONE, indexes);
-        } else if (input.startsWith("delete")) {
-            String indexes = input.substring(6).trim();
-            if (indexes.length() == 0) {
-                throw new InvalidActionException("Please enter the task number which you want to delete.");
-            }
-            return Command.of(CommandTypes.DELETE, indexes);
-        } else if (input.startsWith("find")) {
-            String queries = input.replace("find ", "");
-            return Command.of(CommandTypes.FIND, queries);
-        } else if (input.startsWith("event") || input.startsWith("deadline") || input.startsWith("todo")) {
-            return Command.of(CommandTypes.MAKE, input);
-        } else {
-            throw new UnknownCommandException("Unknown command entered.");
         }
+
+        throw new UnknownCommandException("Unknown command entered");
     }
 
-
+    private String cleanCommandArguments(String input, String alias, CommandTypes commandType) {
+        if (commandType == CommandTypes.QUIT
+                || commandType == CommandTypes.LIST) {
+            return null;
+        } else if (commandType == CommandTypes.DELETE
+                || commandType == CommandTypes.MARKDONE
+                || commandType == CommandTypes.FIND) {
+            String userInput = input.replace(alias, "").trim();
+            return userInput;
+        } else if (commandType == CommandTypes.MAKE) {
+            return input;
+        } else {
+            return input;
+        }
+    }
 }


### PR DESCRIPTION
Commands are strictly matched and the parser uses many if/else
statements to check which command to invoke.

Refactor the `Parser.java` class to be more flexible with various commands, as
well as give the `CommandType` enum room to store aliases for commands.

Implementing such flexibility allows for easier extensions of more
command types and command aliases in the future.

The idea for extending the enum came from
[this StackOverflow post](https://stackoverflow.com/questions/4197988/java-enum-valueof-with-multiple-values/4198066#4198066).